### PR TITLE
Fix for invalid game files being generated on Unix

### DIFF
--- a/source/hccode.c
+++ b/source/hccode.c
@@ -989,10 +989,10 @@ void CodeLine(void)
 					else
 						goto CommaError;
 
+					int resolve_data[15] = { 0 };
+					
 					for (j=0; j<(int)(compend-compstart); j++)
 					{
-						int resolve_data[15] = { 0 };
-
 						fseek(objectfile, compstart+j, SEEK_SET);
 						a = fgetc(objectfile);
 						fseek(objectfile, 0, SEEK_END);


### PR DESCRIPTION
Moved array initialization outside a loop to avoid undefined behavior. Fixes the issue discussed at https://intfiction.org/t/hugo-unix-compiler-crashes-when-referring-to-consecutive-nouns/48782/7

Related to this, I find this piece of code inside the loop a bit suspect but I don't really know what it's doing to tell if it's working correctly or not: https://github.com/0branch/hugo-unix/blob/456ca639aa1afcb4aab7f8ea2b41756b1804fb2e/source/hccode.c#L1002-L1011

To me it seems like as `j` grows it checks all tokens for `ROUTINE_T` and `ARRAY_T`, not just the "initial value" (although I don't know what that means exactly so maybe there's no problem here.)

Also, I couldn't make `j` larger than 6 regardless of how many commas there were in the comparison. If there's some way for it to become larger than 14 then there should be a separate check to avoid overshooting the array.