### PR TITLE
writing and reading negative numbers to and from file

### DIFF
--- a/source/heexpr.c
+++ b/source/heexpr.c
@@ -686,7 +686,15 @@ int GetVal()
 					ioerror = true;
 					retflag = true;
 				}
-				else val = low + high*256;
+				else
+				{
+				 	i = low + high*256;
+#if !defined (MATH_16BIT)
+					if (i > 32767)
+						i -= 65536;
+#endif
+					val = i;
+				}
 			}
 			codeptr++;
 			break;

--- a/source/herun.c
+++ b/source/herun.c
@@ -2154,6 +2154,10 @@ LeaveBreak:
 Writevalloop:
 				codeptr++;
 				i = GetValue();
+#if !defined (MATH_16BIT)
+				if (i < 0)
+					i += 65536;
+#endif
 				if (ioblock)
 				{
 					if ((ioblock==2)


### PR DESCRIPTION
The method Hugo writes and reads values to file is limited to unsigned numbers so the value of negative numbers get mangled in the process.   This fixes that.