### PR TITLE
Import changes from Gargoyle

### DIFF
--- a/heglk/heglk.c
+++ b/heglk/heglk.c
@@ -36,9 +36,7 @@ char just_cleared_screen = false;
 
 #define STAT_UNAVAILABLE (-1)
 
-#ifdef GARGLK
-#include "hemedia.c"	/* gargoyle! */
-#endif
+#include "hemedia.c"
 
 /* glk_main
 

--- a/heglk/heglkunix.c
+++ b/heglk/heglkunix.c
@@ -82,7 +82,9 @@ glkunix_startup_error (char *fmt, ...)
     }
   va_end (ap);
 }
-  
+
+char *hugo_path_to_game;
+
 int
 glkunix_startup_code (glkunix_startup_t *data)
 {
@@ -104,12 +106,29 @@ glkunix_startup_code (glkunix_startup_t *data)
       return FALSE;
     }
 
+  char *s;
+  s = strrchr(data->argv[1], '/');
+  if (!s) s = strrchr(data->argv[1], '\\');
+
 #ifdef GARGLK
-    char *s;
-    s = strrchr(data->argv[1], '/');
-    if (!s) s = strrchr(data->argv[1], '\\');
-    garglk_set_story_name(s ? s + 1 : data->argv[1]);
+  garglk_set_story_name(s ? s + 1 : data->argv[1]);
 #endif
+
+  hugo_path_to_game = calloc(1, strlen(data->argv[1]) + 1);
+  if (hugo_path_to_game == NULL)
+    {
+      glkunix_startup_error ("Error: out of memory");
+      return FALSE;
+    }
+
+  if (s != NULL)
+    {
+      memcpy(hugo_path_to_game, data->argv[1], s - data->argv[1]);
+    }
+  else
+    {
+      strcpy(hugo_path_to_game, data->argv[1]);
+    }
 
   glkunix_set_base_file(data->argv[1]);
   game = glkunix_stream_open_pathname (data->argv[1], 0, 0);

--- a/source/heheader.h
+++ b/source/heheader.h
@@ -277,8 +277,8 @@ void arc_colour(unsigned char n, unsigned int c);
 
 #include "glk.h"
 
-#ifdef GARGLK
-#undef WIN32 /* Gargoyle is not WinGlk */
+#ifdef HUGO_GLKUNIX
+extern char *hugo_path_to_game;
 #endif
 
 #define PORT_NAME "Glk"
@@ -355,11 +355,6 @@ void heglk_printfatalerror(char *err);
 #define SEEK_SET	seekmode_Start
 #undef SEEK_END
 #define SEEK_END	seekmode_End
-
-#if defined (_WINDOWS)
-#define SETTITLE_SUPPORTED
-#define PRINTFATALERROR_SUPPLIED
-#endif
 
 #endif /* defined (GLK) */
 
@@ -501,7 +496,11 @@ extern FILE *hugo_fopen (char *filename, char *mode);
 	by Kent Tessman
 ---------------------------------------------------------------------------*/
 
-#if defined (WIN32) && !defined (WXWINDOWS)
+// For some reason, CMake defines WIN32 when building with MSVC, even though
+// MSVC itself defines _WIN32, which is sufficient for determining if you're
+// on Windows. All these ports really ought to be mututally exclusive, but
+// for the time being, just don't do Windows-specific stuff here with Glk.
+#if defined (WIN32) && !defined (WXWINDOWS) && !defined (GLK)
 
 #ifdef UNDER_CE
 #define PORT_NAME "WinCE"

--- a/source/heres.c
+++ b/source/heres.c
@@ -24,6 +24,9 @@
 
 #include "heheader.h"
 
+#ifdef HUGO_GLKUNIX
+#include "glkstart.h"
+#endif
 
 /* Function prototypes: */
 long FindResource(char *filename, char *resname);
@@ -370,6 +373,12 @@ long FindResource(char *filename, char *resname)
 		}
 #else
 	/* Glk implementation */
+#ifdef HUGO_GLKUNIX
+	// Under Unix Glk, use glkunix_stream_open_pathname to directly open a file.
+	char temp[1024];
+	snprintf(temp, sizeof temp, "%s/%s", hugo_path_to_game, filename);
+	resource_file = glkunix_stream_open_pathname(temp, 0, 0);
+#else
 	fref = glk_fileref_create_by_name(fileusage_Data | fileusage_BinaryMode,
 		filename, 0);
 	if (glk_fileref_does_file_exist(fref))
@@ -377,6 +386,7 @@ long FindResource(char *filename, char *resname)
 	else
 		resource_file = NULL;
 	glk_fileref_destroy(fref);
+#endif
 	if (!resource_file)
 	{
 		var[system_status] = STAT_NOFILE;
@@ -473,6 +483,10 @@ NotinResourceFile:
 		}
 #else
 	/* Glk implementation */
+#ifdef HUGO_GLKUNIX
+	snprintf(temp, sizeof temp, "%s/%s", hugo_path_to_game, resname);
+	resource_file = glkunix_stream_open_pathname(temp, 0, 0);
+#else
 	fref = glk_fileref_create_by_name(fileusage_Data | fileusage_BinaryMode,
 		resname, 0);
 	if (glk_fileref_does_file_exist(fref))
@@ -480,6 +494,7 @@ NotinResourceFile:
 	else
 		resource_file = NULL;
 	glk_fileref_destroy(fref);
+#endif
 	if (!resource_file)
 	{
 		if (!strcmp(filename, ""))


### PR DESCRIPTION
* Multimedia code is now Glk agnostic instead of requiring Gargoyle (but see below).
* GARGLK was effectively being used as a proxy for Unix Glk; a new HUGO_GLKUNIX macro is now tested so all Unix Glks can be used.
* Sound loading code has been consolidated to avoid duplication.

The multimedia loading is still idiosyncratic: Hugo doesn't use Blorb, so workarounds have to be done. If GLK_MODULE_GARGLK_FILE_RESOURCES is available, resources are loaded directly from Hugo's resource files. Otherwise, the rather messy method of writing out PIC and SND files as described in the Blorb specification §16 is used. If a particular Glk implementation supports neither of these, it won't get sound and graphics.